### PR TITLE
categen 2.2.0

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -1,0 +1,25 @@
+1. src.categen.catentry.CatalogueEntry
+      Modified export to now compress pickled data,
+      add seperate function to export pure pickled data
+      (export and pure_export respectively)
+
+      Remove score from formatting
+
+   src.categen.catentry
+      Added import_instance  that loads an
+      exported CatalogueEntry object into an object,
+      alongside a "pure" variant
+      (import_instance and import_pure_instance
+      respectively)
+
+   src.categen.cli
+      Try to use re to regex match current working
+      directory name if matches ii.*-...-......
+      (ii5_3-001-123456, ii6-001-123456 valid)
+      and ask user if they would want to set eid
+      and hid as inferred from cwd name
+
+      Remove score from questions asked
+
+   pyproject.toml
+      Bump version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,3 +31,8 @@ jobs:
         env:
           XDG_DATA_DIR: /home/runner/work/categen
         run: python -m tests.git
+      - name: Pickling
+        if: ${{ always() }}
+        env:
+          XDG_DATA_DIR: /home/runner/work/categen
+        run: python -m tests.pickle

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ preview = Image.open('tests/verycool23ar.png').convert('RGBA')
 generator = CatalogueGenerator(
     eid=1,
     hid=177013,
-    score="7.5",
     desc="the sheer cursery"
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iicategen"
-version = "2.1.5"
+version = "2.1.6"
 description = "A Catalogue Entry Generator for interesting images."
 authors = ["hysrx <rxyth@criptext.com>"]
 repository = "https://github.com/interestingimages/categen"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iicategen"
-version = "2.1.6"
+version = "2.2.0"
 description = "A Catalogue Entry Generator for interesting images."
 authors = ["hysrx <rxyth@criptext.com>"]
 repository = "https://github.com/interestingimages/categen"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "iicategen"
-version = "2.1.4"
+version = "2.1.5"
 description = "A Catalogue Entry Generator for interesting images."
 authors = ["hysrx <rxyth@criptext.com>"]
 repository = "https://github.com/interestingimages/categen"
 license = "MIT"
 readme = "README.md"
 packages = [
-    { include = 'categen', from = 'src' }
+    { include = "categen", from = "src" }
 ]
 
 [tool.poetry.scripts]

--- a/src/categen/catentry.py
+++ b/src/categen/catentry.py
@@ -70,6 +70,9 @@ class CatalogueEntry:
     ) -> None:
         self.config = data.Config()
 
+        self.submission = "Official Submission"
+        self.rating = ""
+
         if not Path(self.config["Repository"]["path"]).is_dir():
             print(
                 f'categen: {self.config["Repository"]["path"]} is non-existant, '
@@ -238,8 +241,8 @@ class CatalogueEntry:
             fword("parody"): ", ".join([t.name for t in self.doujin.parody]),
             fword("characters"): ", ".join([t.name for t in self.doujin.character]),
             fword("slink"): f"nh.{self.doujin.id}",
-            fword("submission"): "",
-            fword("rating"): "",
+            fword("submission"): self.submission,
+            fword("rating"): self.rating,
         }
 
         for keyword, replacement in format_map.items():

--- a/src/categen/catentry.py
+++ b/src/categen/catentry.py
@@ -66,7 +66,11 @@ class CatalogueEntry:
     }
 
     def __init__(
-        self, eid: int, hid: int, score: str, desc: str = "", markdown: str = "Telegram"
+        self,
+        eid: int,
+        hid: int,
+        desc: str = "",
+        markdown: str = "Telegram",
     ) -> None:
         self.config = data.Config()
 
@@ -96,7 +100,6 @@ class CatalogueEntry:
 
         self.markdown = self.markdown_map[markdown]
         self.id = "0" * (3 - len(str(eid))) + str(eid)
-        self.score = str(score)
         self.description = str(desc)
 
         assert self.config["Settings"]["divide"] in ["both", "left", "right"], (
@@ -217,8 +220,7 @@ class CatalogueEntry:
             "mcode": markdown["mcode"][0],
             "-mcode": markdown["mcode"][1],
             fword("entry_id"): self.id,
-            fword("score"): self.score,
-            fword("description"): self.description,
+            fword("description"): "\n" + self.description,
             fword("title.english"): self._divide(self.doujin.title()),
             fword("title.english.pretty"): title_p_en,
             fword("title.japanese:"): self._divide(self.doujin.title(Format.Japanese)),
@@ -309,7 +311,26 @@ class CatalogueEntry:
         self._entry = self._strf(self.entry_text, markdown_type=markdown_type)
         return self._entry
 
-    def export(self) -> bytes:
+    def export(self, level: int = 4) -> bytes:
+        from bz2 import compress
+        from dill import dumps
+
+        return compress(dumps(self), compresslevel=level)
+
+    def pure_export(self) -> bytes:
         from dill import dumps
 
         return dumps(self)
+
+
+def import_instance(dilled: bytes) -> CatalogueEntry:
+    from bz2 import decompress
+    from dill import loads
+
+    return loads(decompress(dilled))
+
+
+def import_pure_instance(dilled: bytes) -> CatalogueEntry:
+    from dill import loads
+
+    return loads(dilled)

--- a/src/categen/catentry.py
+++ b/src/categen/catentry.py
@@ -260,7 +260,7 @@ class CatalogueEntry:
                     # keyword:-sep-:\nkeyword\n
                     _keyword = keyword
                     keyword = keyword.split(":-sep-:")[0]
-                    override = _keyword.lstrip(keyword + ':-sep-:')
+                    override = _keyword.lstrip(keyword + ":-sep-:")
 
                     replacement = self._strf(
                         text=override,

--- a/src/categen/catentry.py
+++ b/src/categen/catentry.py
@@ -220,7 +220,7 @@ class CatalogueEntry:
             "mcode": markdown["mcode"][0],
             "-mcode": markdown["mcode"][1],
             fword("entry_id"): self.id,
-            fword("description"): "\n" + self.description,
+            fword("description"): self.description,
             fword("title.english"): self._divide(self.doujin.title()),
             fword("title.english.pretty"): title_p_en,
             fword("title.japanese:"): self._divide(self.doujin.title(Format.Japanese)),
@@ -256,6 +256,7 @@ class CatalogueEntry:
                 "creator.group" in keyword and replacement == "",
                 "description" in keyword and replacement == "",
                 "tags.remainder" in keyword and replacement == "",
+                "rating" in keyword and replacement == "",
             ]
             if not any(conditions):
                 if ":-sep-:" in keyword:

--- a/src/categen/cli.py
+++ b/src/categen/cli.py
@@ -1,7 +1,6 @@
 from .catentry import CatalogueEntry, data
 from time import sleep, time
 from pathlib import Path
-from re import findall
 from PIL import Image
 from os import mkdir
 import colorama
@@ -197,24 +196,31 @@ def gather_responses() -> dict:
         "Entry Platform Export (Optional)": (Validator.platform, "platform", False),
         "Export Generator? (yY/nN - Optional: No)": (Validator.yesno, "export", False),
     }
-    dirrgx = findall("ii.*-...-......", Path(".").absolute().name)
 
-    if len(dirrgx) == 1:
-        # ii5_3-001-300000
-        # ..vid.eid.hid---
-        _, eid, hid = dirrgx[0].replace("ii", "").split("-")
+    try:
+        from re import findall
 
-        if ask(
-            f"Directory Inferred Defaults: EID:{eid} and HID:{hid} (yY/nN - Optional: No)",
-            validator=Validator.yesno,
-            required=False,
-        ):
-            request_validate_map.pop("Entry ID")
-            request_validate_map.pop("Doujin ID")
-            responses["eid"] = eid
-            responses["hid"] = hid
+        dirrgx = findall("ii.*-...-......", Path(".").absolute().name)
 
-        print()
+        if len(dirrgx) == 1:
+            # ii5_3-001-300000
+            # ..vid.eid.hid---
+            _, eid, hid = dirrgx[0].replace("ii", "").split("-")
+
+            if ask(
+                f"Directory Inferred Defaults: EID:{eid} and HID:{hid} (yY/nN - Optional: No)",
+                validator=Validator.yesno,
+                required=False,
+            ):
+                request_validate_map.pop("Entry ID")
+                request_validate_map.pop("Doujin ID")
+                responses["eid"] = eid
+                responses["hid"] = hid
+
+            print()
+
+    except Exception:
+        pass
 
     try:
         config = data.Config()

--- a/tests/gen/all.py
+++ b/tests/gen/all.py
@@ -14,7 +14,7 @@ def main(test: str = "all"):
     )
 
     eid = 69
-    hid = 177013
+    hid = 300000
 
     collector = utils.TracebackCollector()
     stsmgr = categen.cli.StatusManager()

--- a/tests/gen/all.py
+++ b/tests/gen/all.py
@@ -39,9 +39,7 @@ def main(test: str = "all"):
 
     # Operations
     def gencreate():
-        return categen.CatalogueEntry(
-            eid=eid, hid=hid, score="test", desc="No description provided."
-        )
+        return categen.CatalogueEntry(eid=eid, hid=hid, desc="No description provided.")
 
     generator = utils.attempt(gencrt, collector, gencreate)
 

--- a/tests/gen/all.py
+++ b/tests/gen/all.py
@@ -42,6 +42,8 @@ def main(test: str = "all"):
         return categen.CatalogueEntry(eid=eid, hid=hid, desc="No description provided.")
 
     generator = utils.attempt(gencrt, collector, gencreate)
+    generator.submission = "Test Submission"
+    generator.rating = "47% Upvoted"
 
     if generator is None:
         collector.display()

--- a/tests/pickle.py
+++ b/tests/pickle.py
@@ -1,0 +1,51 @@
+from src import categen
+from tests import utils
+import colorama
+
+
+def main():
+    print(
+        f"{colorama.Style.BRIGHT}interesting images"
+        f"{colorama.Style.RESET_ALL} Tests / Pickling\n"
+    )
+
+    traces = utils.TracebackCollector()
+    stsmgr = categen.cli.StatusManager()
+
+    gencrt = stsmgr.register("Generator Creation")
+    entgen = stsmgr.register("Entry Generation")
+    pexpop = stsmgr.register("Pure Export")
+    exptop = stsmgr.register("Export")
+    imptop = stsmgr.register("Import")
+
+    def op_gencrt():
+        return categen.CatalogueEntry(eid=1, hid=300000)
+
+    catentry = utils.attempt(gencrt, traces, op_gencrt)
+
+    def op_entegen(catentry: categen.CatalogueEntry):
+        catentry.entry()
+
+    utils.attempt(entgen, traces, op_entegen, catentry)
+
+    def op_pexpop(catentry: categen.CatalogueEntry):
+        return {"text": f"Size: {len(catentry.pure_export())}"}
+
+    utils.attempt(pexpop, traces, op_pexpop, catentry)
+
+    def op_exptop(catentry: categen.CatalogueEntry):
+        _op = catentry.export()
+        return {"result": _op, "text": f"Size: {len(_op)}"}
+
+    exp = utils.attempt(exptop, traces, op_exptop, catentry)
+
+    def op_imptop(catentry: categen.CatalogueEntry, dilled: bytes):
+        categen.catentry.instance(dilled)
+
+    utils.attempt(imptop, traces, op_imptop, catentry, exp)
+
+    traces.display()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changelog
### Major
  - Update Format
  - Use regex matching if possible to detect if current working directory name matches `ii.*-...-......` in the CLI script
  - **Removed score from entry, formatting and CatalogueEntry class params**

### Minor
  - **categen.export is now categen.pure_export, with export now returning a bz2 compressed version of the pickled data.**
  - Added import_instance and import_pure_instance to categen